### PR TITLE
🔨 Fix : DB 저장용 식당, 카페 데이터 수집 API 생성

### DIFF
--- a/TWT_BE/build.gradle
+++ b/TWT_BE/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'com.google.code.gson:gson:2.9.0'
 
 	// 웹 크롤링 jsoup : 정적페이지 / selenium : 동적페이지 ( 개발자 도구 에서 Disable Js 했을 때 자료 뜨면 정적, 안뜨면 동적 )
 	implementation 'org.jsoup:jsoup:1.14.2'

--- a/TWT_BE/src/main/java/com/BE/TWT/controller/ScrapController.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/controller/ScrapController.java
@@ -1,0 +1,22 @@
+package com.BE.TWT.controller;
+
+import com.BE.TWT.crawling.ScrapStay;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.validation.Valid;
+import java.io.IOException;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/scrap")
+public class ScrapController {
+    private final ScrapStay scrapStay;
+    @PostMapping("/stay")
+    public void scrapStay(@RequestParam @Valid String url) throws IOException {
+        scrapStay.scrapStayData(url);
+    }
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/crawling/KakaoLocationSearch.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/crawling/KakaoLocationSearch.java
@@ -1,0 +1,94 @@
+package com.BE.TWT.crawling;
+
+import com.BE.TWT.exception.error.MapException;
+import com.BE.TWT.exception.message.MapErrorMessage;
+import com.BE.TWT.model.dto.AddressResponse;
+import com.BE.TWT.model.type.BuildType;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoLocationSearch {
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+    private String[] code = {"AD5", "FD6", "CE7", "AT4"}; // 숙박, 식당, 카페, 관광명소 request category_group_code= +
+
+    public AddressResponse searchLocation(String building) throws MapException {
+
+        String reqURL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+        String buildType = code[1];
+        BuildType type = null;
+        if (buildType.equals(code[1])) {
+            type = BuildType.RESTAURANT;
+        }
+        if (buildType.equals(code[2])) {
+            type = BuildType.CAFE;
+        }
+        if (buildType.equals(code[3])) {
+            type = BuildType.PLACE;
+        }
+
+        try {
+            String encodedQuery = URLEncoder.encode(building, "UTF-8");
+            String request = "?page=1&size=15&sort=accuracy&category_group_code=" + buildType + "&query=" + encodedQuery;
+            URL url = new URL(reqURL + request);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("GET");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Authorization", "KakaoAK " + kakaoApiKey);
+
+            double longitude = 0;
+            double latitude = 0;
+            String address = "";
+            String phone = "";
+
+            //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+
+            //Gson 라이브러리로 JSON파싱
+            JsonParser parser = new JsonParser();
+            JsonObject jsonObject = parser.parse(result).getAsJsonObject();
+
+            JsonArray documents = jsonObject.getAsJsonArray("documents");
+            for (JsonElement docElement : documents) {
+                JsonObject docObject = docElement.getAsJsonObject();
+                longitude = docObject.getAsJsonObject().get("x").getAsDouble();
+                latitude = docObject.getAsJsonObject().get("y").getAsDouble();
+                address = docObject.getAsJsonObject().get("road_address_name").getAsString();
+                phone = docObject.getAsJsonObject().get("phone").getAsString();
+            }
+            AddressResponse addressResponse = AddressResponse.builder()
+                    .address(address)
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .phone(phone)
+                    .buildType(type)
+                    .build();
+
+            return addressResponse;
+
+        } catch (IOException e) {
+            throw new MapException(MapErrorMessage.INVALID_ADDRESS);
+        }
+    }
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/crawling/ScrapStay.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/crawling/ScrapStay.java
@@ -1,0 +1,118 @@
+package com.BE.TWT.crawling;
+
+import com.BE.TWT.exception.error.MapException;
+import com.BE.TWT.exception.message.MapErrorMessage;
+import com.BE.TWT.model.dto.AddressResponse;
+import com.BE.TWT.model.entity.Stay;
+import com.BE.TWT.model.type.PlaceType;
+import com.BE.TWT.repository.StayRepository;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+@Service
+@RequiredArgsConstructor
+public class ScrapStay {
+    private final StayRepository stayRepository;
+
+
+        public void scrapStayData (String url) throws IOException {
+
+        Document document = Jsoup.connect(url).get();
+        Elements hotelElements = document.select("[data-testid=\"property-card\"]");
+
+        for (Element element : hotelElements) {
+            String name = element.select("[data-testid=\"title\"]").text();
+            String imageUrl = element.select("img").attr("src");
+            String description = element.select("div.d8eab2cf7f").text();
+            int idx = description.lastIndexOf(".");
+            description = description.substring(0, idx + 1); // . 뒤에 ~~개의 후기 라는 단어 제거하기 위함
+
+            AddressResponse addressResponse = searchLocation(name);
+
+            Stay stay = Stay.builder()
+                    .stayName(name)
+                    .stayAddress(addressResponse.getAddress())
+                    .latitude(addressResponse.getLatitude())
+                    .longitude(addressResponse.getLongitude())
+                    .stayDescription(description)
+                    .stayImageUrl(imageUrl)
+                    .stayCallNumber(addressResponse.getPhone())
+                    .placeType(PlaceType.STAY)
+                    .stayLocation("대구")
+                    .build();
+            if (stayRepository.findByStayName(name).isEmpty()) {
+                stayRepository.save(stay);
+            }
+        }
+    }
+
+    public AddressResponse searchLocation(String building) throws MapException {
+        String kakaoApiKey = "0ad552da7c60e0f4fa43e783b08091a8";
+
+        String reqURL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+
+        try {
+            String encodedQuery = URLEncoder.encode(building, "UTF-8");
+            String request = "?page=1&size=15&sort=accuracy&category_group_code=AD5" + "&query=" + encodedQuery;
+            URL url = new URL(reqURL + request);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("GET");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Authorization", "KakaoAK " + kakaoApiKey);
+
+            double longitude = 0;
+            double latitude = 0;
+            String address = "";
+            String phone = "";
+
+            //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+
+            //Gson 라이브러리로 JSON파싱
+            JsonParser parser = new JsonParser();
+            JsonObject jsonObject = parser.parse(result).getAsJsonObject();
+
+            JsonArray documents = jsonObject.getAsJsonArray("documents");
+            for (JsonElement docElement : documents) {
+                JsonObject docObject = docElement.getAsJsonObject();
+                longitude = docObject.getAsJsonObject().get("x").getAsDouble();
+                latitude = docObject.getAsJsonObject().get("y").getAsDouble();
+                address = docObject.getAsJsonObject().get("road_address_name").getAsString();
+                phone = docObject.getAsJsonObject().get("phone").getAsString();
+            }
+            AddressResponse addressResponse = AddressResponse.builder()
+                    .address(address)
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .phone(phone)
+                    .build();
+
+            return addressResponse;
+
+        } catch (IOException e) {
+            throw new MapException(MapErrorMessage.INVALID_ADDRESS);
+        }
+    }
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/exception/error/MapException.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/exception/error/MapException.java
@@ -1,0 +1,13 @@
+package com.BE.TWT.exception.error;
+
+import com.BE.TWT.exception.message.MapErrorMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.io.IOException;
+
+@Getter
+@AllArgsConstructor
+public class MapException extends IOException {
+    private final MapErrorMessage mapErrorMessage;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/exception/message/MapErrorMessage.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/exception/message/MapErrorMessage.java
@@ -1,0 +1,15 @@
+package com.BE.TWT.exception.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MapErrorMessage {
+    INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "올바르지 않은 주소입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String errorMessage;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/dto/AddressResponse.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/dto/AddressResponse.java
@@ -1,0 +1,23 @@
+package com.BE.TWT.model.dto;
+
+import com.BE.TWT.model.type.BuildType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddressResponse {
+    private String address;
+    private double longitude; // x
+    private double latitude; // y
+    private String phone;
+    @Enumerated(EnumType.STRING)
+    private BuildType buildType;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/dto/Point.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/dto/Point.java
@@ -1,0 +1,14 @@
+package com.BE.TWT.model.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Point {
+    private double latitude;
+    private double longitude;
+
+    public Point(double latitude, double longitude){
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/entity/Stay.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/entity/Stay.java
@@ -1,0 +1,44 @@
+package com.BE.TWT.model.entity;
+
+import com.BE.TWT.model.type.PlaceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Stay {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String stayName;
+    @Column(nullable = false)
+    private String stayLocation; // 필터용 지역
+    @Column(nullable = false)
+    private String stayAddress; // 숙소 상세주소
+    private double latitude;
+    private double longitude;
+    @Column(nullable = false)
+    private String stayImageUrl;
+    @Column(nullable = false)
+    private String stayDescription;
+
+    private int stayLove; // 좋아요
+
+    private double star; // 별점
+
+    private String stayCallNumber;
+
+    @Enumerated(EnumType.STRING)
+    private PlaceType placeType;
+
+//    private List<Review> reviewList;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/entity/location/Restaurant.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/entity/location/Restaurant.java
@@ -1,0 +1,42 @@
+package com.BE.TWT.model.entity.location;
+
+import com.BE.TWT.model.type.PlaceType;
+import com.BE.TWT.model.type.BuildType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Restaurant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String restaurantName;
+    @Column(nullable = false)
+    private String restaurantLocation; // 필터용 지역
+    @Column(nullable = false)
+    private String restaurantAddress; // 숙소 상세주소
+    private double latitude;
+    private double longitude;
+    @Column(nullable = false)
+    private String restaurantImageUrl;
+    @Column(nullable = false)
+    private String restaurantDescription;
+    private String restaurantCallNumber;
+    @Enumerated(EnumType.STRING)
+    private BuildType buildType;
+
+    private int restaurantLove; // 좋아요
+
+    private double star; // 별점
+
+    @Enumerated(EnumType.STRING)
+    private PlaceType placeType;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/type/BuildType.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/type/BuildType.java
@@ -1,0 +1,12 @@
+package com.BE.TWT.model.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BuildType {
+    CAFE("카페"), RESTAURANT("식당"), PLACE("명소") ;
+
+    private final String place;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/model/type/PlaceType.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/model/type/PlaceType.java
@@ -1,0 +1,12 @@
+package com.BE.TWT.model.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceType {
+    HOT_PLACE("명소"), STAY("숙소"), RESTAURANT("식당");
+
+    private final String place;
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/repository/StayRepository.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/repository/StayRepository.java
@@ -1,0 +1,12 @@
+package com.BE.TWT.repository;
+
+import com.BE.TWT.model.entity.Stay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StayRepository extends JpaRepository<Stay, Long> {
+    Optional<Stay> findByStayName(String stayName);
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/repository/location/RestaurantRepository.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/repository/location/RestaurantRepository.java
@@ -1,0 +1,9 @@
+package com.BE.TWT.repository.location;
+
+import com.BE.TWT.model.entity.location.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/service/map/PointService.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/service/map/PointService.java
@@ -1,0 +1,52 @@
+package com.BE.TWT.service.map;
+
+import com.BE.TWT.exception.error.MapException;
+import com.BE.TWT.exception.message.MapErrorMessage;
+import com.BE.TWT.model.dto.Point;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static com.BE.TWT.exception.message.MapErrorMessage.INVALID_ADDRESS;
+
+@Service
+public class PointService {
+    @Value("${spring.map.key}")
+    private String apiKey;
+    private final String EPSG = "epsg:4326";
+
+    public Point getMapString (String address) throws MapException {
+        StringBuilder sb = new StringBuilder("https://api.vworld.kr/req/address");
+        sb.append("?service=address");
+        sb.append("&request=getCoord");
+        sb.append("&format=json");
+        sb.append("&crs=" + EPSG);
+        sb.append("&key=" + apiKey);
+        sb.append("&address=" + URLEncoder.encode(address, StandardCharsets.UTF_8));
+
+        try{
+            URL url = new URL(sb.toString());
+            BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
+
+            JsonParser jspa = new JsonParser();
+            JsonObject jsob = jspa.parse(reader).getAsJsonObject();
+            JsonObject jsrs = jsob.get("response").getAsJsonObject();
+            JsonObject jsResult = jsrs.get("result").getAsJsonObject();
+            JsonObject jspoitn = jsResult.get("point").getAsJsonObject();
+
+            String jsonLongitude = jspoitn.get("y").getAsString();
+            String jsonLatitude = jspoitn.get("x").getAsString();
+            return new Point(Double.parseDouble(jsonLongitude),Double.parseDouble(jsonLatitude));
+        } catch (IOException e) {
+            throw new MapException(INVALID_ADDRESS);
+        }
+    }
+}

--- a/TWT_BE/src/main/java/com/BE/TWT/service/point/PointService.java
+++ b/TWT_BE/src/main/java/com/BE/TWT/service/point/PointService.java
@@ -1,7 +1,6 @@
-package com.BE.TWT.service.map;
+package com.BE.TWT.service.point;
 
 import com.BE.TWT.exception.error.MapException;
-import com.BE.TWT.exception.message.MapErrorMessage;
 import com.BE.TWT.model.dto.Point;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;


### PR DESCRIPTION
## 💡개요

지역별 맛집 식당, 카페 DB 저장

## 🛠️작업사항

숙소와 달리 자료 크롤링 허용 사이트를 찾지 못함.
1. Naver 검색 API 로 {지역이름} {한식, 중식, ... } 검색하여 식당 찾기
2. 위, 경도 좌표 API 로 해당 식당 위, 경도 값 추가
3. 이후 검색 / 필터 기능으로 카페 , 식당 등 구분할 경우가 생길 수 있으므로 BuildType Enum Type 추가하여 식당 , 카페 분류