### PR TITLE
Feature/frontend/schedule page

### DIFF
--- a/TWT_FE/package-lock.json
+++ b/TWT_FE/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.1",
         "react-icons": "^4.10.1",
+        "react-kakao-maps-sdk": "^1.1.11",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
@@ -12049,6 +12050,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.38.tgz",
+      "integrity": "sha512-ub3ITsp/XfM7OikRvnsQiK6oZgyqVKVvGm9bmChudfDRjFa6xrS2O/bLNs0EyFCQZufVBXLLJK9+T06LOYxNiw=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -14914,6 +14920,18 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.11.tgz",
+      "integrity": "sha512-L3hHa7tvVCxEvU3R4DODctLQMNMEqUUkWweSgVrD/9qndeB3+Fk5FUUFRW5muVghwr4PQ2fzR1jhk6vO35TDaA==",
+      "dependencies": {
+        "kakao.maps.d.ts": "^0.1.38"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
     },
     "node_modules/react-query": {
       "version": "3.39.3",
@@ -26809,6 +26827,11 @@
         "object.values": "^1.1.6"
       }
     },
+    "kakao.maps.d.ts": {
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.38.tgz",
+      "integrity": "sha512-ub3ITsp/XfM7OikRvnsQiK6oZgyqVKVvGm9bmChudfDRjFa6xrS2O/bLNs0EyFCQZufVBXLLJK9+T06LOYxNiw=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -28711,6 +28734,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-kakao-maps-sdk": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.11.tgz",
+      "integrity": "sha512-L3hHa7tvVCxEvU3R4DODctLQMNMEqUUkWweSgVrD/9qndeB3+Fk5FUUFRW5muVghwr4PQ2fzR1jhk6vO35TDaA==",
+      "requires": {
+        "kakao.maps.d.ts": "^0.1.38"
+      }
     },
     "react-query": {
       "version": "3.39.3",

--- a/TWT_FE/package.json
+++ b/TWT_FE/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.1",
     "react-icons": "^4.10.1",
+    "react-kakao-maps-sdk": "^1.1.11",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",

--- a/TWT_FE/src/App.tsx
+++ b/TWT_FE/src/App.tsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Schedule from './pages/Schedule';
 
 function App() {
   return (
     <div className="App">
       <BrowserRouter>
         <Routes>
-          <Route></Route>
+          <Route path="/schedule" element={<Schedule />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/TWT_FE/src/components/Feeds.tsx
+++ b/TWT_FE/src/components/Feeds.tsx
@@ -1,0 +1,84 @@
+import { MdOutlineFoodBank, MdOutlineAttractions } from 'react-icons/md';
+import { AiOutlineHome } from 'react-icons/ai';
+
+function Feeds({
+  setIsShowModal,
+}: {
+  setIsShowModal: (isShowModal: boolean) => void;
+}) {
+  return (
+    <>
+      <ul
+        aria-label="feed"
+        role="feed"
+        className="relative flex flex-col gap-4 py-12 pl-8 before:absolute before:top-0 before:left-8 before:h-full before:-translate-x-1/2 before:border before:border-dashed before:border-lightgray after:absolute after:top-6 after:left-8 after:bottom-6 after:-translate-x-1/2 after:border after:border-lightgray"
+      >
+        <li className="relative pl-8" role="feed">
+          <div className="absolute text-2xl left-0 z-10 flex items-center justify-center w-10 h-10 text-white -translate-x-1/2 rounded-full bg-blue ring-2 ring-white">
+            <MdOutlineFoodBank />
+          </div>
+          <div className="flex flex-1 gap-0 justify-between items-center">
+            <div>
+              <h4 className="text-base font-semibold">장소명</h4>
+              <p className="text-sm text-gray">10:00</p>
+            </div>
+            <div className="flex flex-col mr-5">
+              <button className="hover:font-semibold text-sm">장소 삭제</button>
+              <button
+                className="hover:font-semibold text-sm"
+                onClick={() => setIsShowModal(true)}
+              >
+                시간 입력
+              </button>
+            </div>
+          </div>
+        </li>
+        <span className="text-sm text-gray -ml-4 z-20 bg-lightgray rounded-lg px-2 py-1 w-fit">
+          123km
+        </span>
+        <li className="relative pl-8" role="feed">
+          <div className="absolute text-2xl left-0 z-10 flex items-center justify-center w-10 h-10 text-white -translate-x-1/2 rounded-full bg-pink-500  ring-2 ring-white">
+            <AiOutlineHome />
+          </div>
+          <div className="flex flex-1 gap-0 justify-between items-center">
+            <div>
+              <h4 className="text-base font-semibold">장소명</h4>
+              <p className="text-sm text-gray">10:00</p>
+            </div>
+            <div className="flex flex-col mr-5">
+              <button className="hover:font-semibold text-sm">장소 삭제</button>
+              <button
+                className="hover:font-semibold text-sm"
+                onClick={() => setIsShowModal(true)}
+              >
+                시간 입력
+              </button>
+            </div>
+          </div>
+        </li>
+        <li className="relative pl-8" role="feed">
+          <div className="absolute text-2xl left-0 z-10 flex items-center justify-center w-10 h-10 text-white -translate-x-1/2 rounded-full bg-amber-500  ring-2 ring-white">
+            <MdOutlineAttractions />
+          </div>
+          <div className="flex flex-1 gap-0 justify-between items-center">
+            <div>
+              <h4 className="text-base font-semibold">장소명</h4>
+              <p className="text-sm text-gray">10:00</p>
+            </div>
+            <div className="flex flex-col mr-5">
+              <button className="hover:font-semibold text-sm">장소 삭제</button>
+              <button
+                className="hover:font-semibold text-sm"
+                onClick={() => setIsShowModal(true)}
+              >
+                시간 입력
+              </button>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </>
+  );
+}
+
+export default Feeds;

--- a/TWT_FE/src/components/TimeModal.tsx
+++ b/TWT_FE/src/components/TimeModal.tsx
@@ -1,0 +1,43 @@
+import { useRef } from 'react';
+
+function TimeModal({
+  setIsShowModal,
+}: {
+  setIsShowModal: (showModal: boolean) => void;
+}) {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      className="fixed top-0 left-0 z-20 flex items-center justify-center w-screen h-screen bg-lightgray/20 backdrop-blur-sm"
+      aria-labelledby="header-5a content-5a"
+      aria-modal="true"
+      tabIndex={-1}
+      role="dialog"
+    >
+      <div
+        ref={wrapperRef}
+        className="flex max-h-[90vh] w-4/5 max-w-2xl flex-col gap-6 overflow-hidden rounded-xl bg-white p-6 shadow-xl"
+        id="modal"
+        role="document"
+      >
+        <header id="header-5a" className="flex gap-4">
+          <h3 className="flex-1 text-xl font-bold">⏰ 시간 추가</h3>
+        </header>
+        <input type="time" />
+        <div className="flex justify-end gap-2">
+          <button className="inline-flex items-center justify-center flex-1 h-10 px-5 text-sm font-semibold tracking-wide duration-300 rounded whitespace-nowrap bg-skyblue/80 hover:bg-skyblue">
+            추가
+          </button>
+          <button
+            className="inline-flex items-center justify-center flex-1 h-10 px-5 text-sm font-semibold tracking-wide duration-300 rounded whitespace-nowrap bg-lightgray hover:bg-gray/40"
+            onClick={() => setIsShowModal(false)}
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TimeModal;

--- a/TWT_FE/src/pages/Schedule.tsx
+++ b/TWT_FE/src/pages/Schedule.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import TimeModal from '../components/TimeModal';
+import Feeds from '../components/Feeds';
+
+import { FaShareSquare } from 'react-icons/fa';
+
+function Schedule() {
+  const [isMoreOpen, setIsMoreOpen] = useState<boolean>(false);
+  const [isShowModal, setIsShowModal] = useState<boolean>(false);
+  return (
+    <>
+      <Header />
+      <section className="bg-lightgray dark:bg-gray-900 h-full flex justify-center flex-col lg:px-40 mobile:px-10 py-6">
+        <div className="bg-white rounded-lg shadow-xl pb-8">
+          <div className="relative w-full h-[300px] bg-darkgray rounded-tl-lg rounded-tr-lg">
+            <img
+              src="https://www.kgnews.co.kr/data/photos/20200729/art_15947805688786_248bf0.jpg"
+              className="w-full h-full rounded-tl-lg rounded-tr-lg opacity-50 blur-sm"
+            />
+          </div>
+          <div className="absolute gap-2 flex flex-col -mt-60 justify-center ml-10">
+            <span className="font-bold text-2xl text-white">강원도 여행</span>
+            <div className="flex gap-2">
+              <span className="text-white underline">2023.07.16 - 07.19</span>
+              {/* 토큰 확인 */}
+              <button className="text-gray text-sm">편집</button>
+            </div>
+            <span className="font-bold text-2xl text-white">D - 00</span>
+          </div>
+          <div className="absoulte flex flex-col items-center">
+            <button className="flex self-end mr-3 text-white -mt-6 z-20 text-xl">
+              <FaShareSquare />
+            </button>
+            <button className="flex self-end mr-4 mt-2 text-gray text-sm z-20">
+              일정 삭제
+            </button>
+            <img
+              src="https://www.kgnews.co.kr/data/photos/20200729/art_15947805688786_248bf0.jpg"
+              className="w-[350px] h-[350px] border-4 border-white rounded-full -mt-40 z-20"
+            />
+          </div>
+
+          <div className="px-6 m-auto mt-10">
+            <div className="grid grid-cols-4 gap-3 tablet:grid-cols-8 lg:grid-cols-12">
+              <div className="flex flex-col items-center justify-center col-span-1 lg:col-span-1">
+                <p className="text-xl font-semibold">Day1</p>
+                <p className="text-xs text-gray">7.16(일)</p>
+              </div>
+              <div className="col-span-7 lg:col-span-11 shadow-md shadow-gray rounded-md px-5 py-5">
+                <Feeds setIsShowModal={setIsShowModal} />
+                <div className="flex justify-center mb-1">
+                  <button
+                    className="text-sm"
+                    onClick={() => setIsMoreOpen(!isMoreOpen)}
+                  >
+                    {isMoreOpen ? '닫기' : '더보기'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      {isShowModal && <TimeModal setIsShowModal={setIsShowModal} />}
+      <Footer />
+    </>
+  );
+}
+
+export default Schedule;

--- a/TWT_FE/tailwind.config.js
+++ b/TWT_FE/tailwind.config.js
@@ -2,19 +2,21 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
   theme: {
-    extend: {},
-    colors: {
-      white: '#ffffff',
-      skyblue: '#90DCE1',
-      blue: '#379EFD',
-      gray: '#9B9B9B',
-      red: '#F40D0D',
-      darkgray: '#1f2937',
-      lightgray: '#F6F6F6',
-      active: 'rgba(0, 0, 0, 0.8)',
-      hoverLink: 'rgba(0, 0, 0, 0.6)',
-      unActive: 'rgba(0, 0, 0, 0.3)',
+    extend: {
+      colors: {
+        white: '#ffffff',
+        skyblue: '#90DCE1',
+        blue: '#379EFD',
+        gray: '#9B9B9B',
+        red: '#F40D0D',
+        darkgray: '#1f2937',
+        lightgray: '#F6F6F6',
+        active: 'rgba(0, 0, 0, 0.8)',
+        hoverLink: 'rgba(0, 0, 0, 0.6)',
+        unActive: 'rgba(0, 0, 0, 0.3)',
+      },
     },
+
     screens: {
       mobile: '360px', // @media (min-width: 360px)
       foldable: '523px', // @media (min-width: 523px)


### PR DESCRIPTION
## 💡개요

일정 상세페이지 구현
- 일별 장소 및 시간 등을 입력하여 여행일정을 짤 수 있음
- 이동하는 장소 순으로 거리 나타냄
- 지도 표시
- 일정 공유 가능

## 🛠️작업사항

- 일별 아코디언 형식 구현
- 시간 입력 모달창 구현
![시간입력모달창](https://github.com/Travel-Without-Trouble-TWT/TWT/assets/87015084/eba48762-3f16-49e9-944f-06a7c064b232)

## ✅변경로직
- 전
    - 너무 frame 형태라 마음에 안듬  
![변경 전_일정상세페이지](https://github.com/Travel-Without-Trouble-TWT/TWT/assets/87015084/bbb6790d-bdad-4321-8d81-5f7321463bd8)
- 후
    - 카테고리별 아이콘으로 나타냄
    - feed 형식으로 변경
![변경 후_일정상세페이지](https://github.com/Travel-Without-Trouble-TWT/TWT/assets/87015084/ce7fc371-5b36-493b-acfd-bf66be6f9d60)


## 🛠️ 추후 작업사항
- 카카오맵 불러오기
- 마커 찍기
- 일정 공유하기
- 지난 일정일 경우 / 유저인 경우 형식 변경